### PR TITLE
Debug docker composition: PHP_VHOST + SMTP conf

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -12,8 +12,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "mysqrootpass"
       MYSQL_ROOT_HOST: '%'
-      SMTP_HOST: 172.18.18.4
-      SMTP_PORT: 1025
     ports:
       - 3306:3306
 
@@ -30,9 +28,12 @@ services:
     environment:
       WORKER_PROCESSES: 4
       VIRTUAL_HOST: whmcs.test
+      PHP_VHOST: whmcs.test
       APP_PASSWORD: userapppassword
       WHMCS_SERVER_IP: 172.18.18.1
       HTTPS: "on"
+      SMTP_HOST: 172.18.18.4
+      SMTP_PORT: 1025
     ports:
       - 80:80
       - 2222:2222

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       WORKER_PROCESSES: 4
       VIRTUAL_HOST: whmcs.test
+      PHP_VHOST: whmcs.test
       APP_PASSWORD: userapppassword
       WHMCS_SERVER_IP: 172.18.18.1
       HTTPS: "on"


### PR DESCRIPTION
The mailhog container is useless because the SMTP_* env var are defined in the mysql container rather than the nginx one. Plus, I added PHP_VHOST env var to nginx container, because without it, it prevents nginx from starting.