### PR TITLE
Fix issue #7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY    build /build
 RUN     build/setup.sh && rm -rf /build
 
 COPY    root/ /
+COPY    --from=ajoergensen/baseimage-ubuntu /etc/service/. /etc/service/
 
 RUN     chmod -v +x /etc/my_init.d/*.sh /etc/service/*/run
 


### PR DESCRIPTION
Hello, this fixes the issue #7 

I have checked and indeed the `sshd` and `cron` are missing from `/etc/service`, on the base image they are present.

The problem lies on the `COPY    root/ /` part of the Dockerfile.

If I'm not mistaken changing from `root/` to `root/.` was supposed to fix the problem.

See: 
- https://github.com/moby/moby/issues/31251
- https://github.com/moby/moby/blob/52df69f00d966904ba230dc2e3a0646cc52b7688/docs/reference/commandline/cp.md

But for some reason its not the case here, so I had to copy from the base image directly.

I should note that SSH and CRON are present on another locations (sbin i think), but since we start the services at `/etc/services` they are not started.
